### PR TITLE
fix: CF WorkersのenvからDATABASE_URLをPrismaに注入する

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import type { Bindings } from "./types/context.js";
+import { initPrismaUrl } from "./lib/prisma.js";
 import authRoutes from "./routes/auth.js";
 import entriesRoutes from "./routes/entries.js";
 import templatesRoutes from "./routes/templates.js";
@@ -11,7 +12,11 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 // Middleware
 app.use("*", logger());
-// CF Workers ではモジュールロード時にシークレットが未注入のため、リクエスト時に読む
+// CF Workers ではリクエスト時の env から DATABASE_URL を Prisma に注入する
+app.use("*", (c, next) => {
+  initPrismaUrl(c.env.DATABASE_URL);
+  return next();
+});
 app.use("*", (c, next) => {
   const origin = c.env.CORS_ORIGIN;
   if (!origin && c.env.NODE_ENV === "production") {

--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -23,7 +23,8 @@ export function initPrismaUrl(url: string) {
 export const prisma = new Proxy({} as ExtendedClient, {
   get(_, prop: string | symbol) {
     if (!_client) {
-      if (!_url) throw new Error("DATABASE_URL が未設定です。initPrismaUrl() を先に呼んでください。");
+      if (!_url)
+        throw new Error("DATABASE_URL が未設定です。initPrismaUrl() を先に呼んでください。");
       _client = createPrismaClient(_url);
     }
     return Reflect.get(_client, prop);

--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -3,18 +3,28 @@ import { withAccelerate } from "@prisma/extension-accelerate";
 
 type ExtendedClient = ReturnType<typeof createPrismaClient>;
 
-function createPrismaClient() {
-  return new PrismaClient().$extends(withAccelerate());
+function createPrismaClient(url: string) {
+  return new PrismaClient({
+    datasources: { db: { url } },
+  }).$extends(withAccelerate());
 }
 
+let _url: string | undefined;
 let _client: ExtendedClient | undefined;
 
-// CF Workers ではモジュールロード時に process.env（シークレット）が利用できないため、
-// 初回アクセス時にクライアントを生成する Proxy を使用して遅延初期化する
+// CF Workers では process.env が使えないため、リクエスト時に env.DATABASE_URL を注入する
+export function initPrismaUrl(url: string) {
+  if (_url !== url) {
+    _url = url;
+    _client = undefined;
+  }
+}
+
 export const prisma = new Proxy({} as ExtendedClient, {
   get(_, prop: string | symbol) {
     if (!_client) {
-      _client = createPrismaClient();
+      if (!_url) throw new Error("DATABASE_URL が未設定です。initPrismaUrl() を先に呼んでください。");
+      _client = createPrismaClient(_url);
     }
     return Reflect.get(_client, prop);
   },

--- a/apps/api/src/types/context.ts
+++ b/apps/api/src/types/context.ts
@@ -12,6 +12,7 @@ export type Variables = {
 export type AuthContext = Context<{ Variables: Variables }>;
 
 export type Bindings = {
+  DATABASE_URL: string;
   CORS_ORIGIN?: string;
   NODE_ENV?: string;
 };


### PR DESCRIPTION
## Summary

- CF Workersでは`process.env`が使えないため、`PrismaClientInitializationError: Environment variable not found: DATABASE_URL`が発生していた
- リクエスト時に`c.env.DATABASE_URL`を`initPrismaUrl()`経由でPrismaクライアントに渡すよう修正
- `Bindings`型に`DATABASE_URL`を追加

## 変更内容

- `prisma.ts`: `initPrismaUrl(url)`関数を追加し、URLを外部から注入できるように変更
- `context.ts`: `Bindings`に`DATABASE_URL: string`を追加
- `app.ts`: 全リクエストで`initPrismaUrl(c.env.DATABASE_URL)`を呼ぶミドルウェアを追加

## Test plan

- [ ] `wrangler secret put DATABASE_URL`でシークレットが設定済みであること
- [ ] デプロイ後、`/api/auth/register`が500エラーなく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * APIのデータベース接続初期化を改善しました。リクエスト単位で接続先を動的に設定できるようになり、接続管理の安定性と柔軟性が向上しました。
  * 型定義や初期化フローを明確化して、環境変数の取り扱いと起動時の挙動を整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->